### PR TITLE
added fragmentation logic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,3 +4,4 @@ linters:
     - nlreturn
     - exhaustivestruct
     - godox
+    - cyclop

--- a/kafka-client/kafka-consumer/kafka_message_assembler.go
+++ b/kafka-client/kafka-consumer/kafka_message_assembler.go
@@ -1,0 +1,79 @@
+package kafkaconsumer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/go-logr/logr"
+)
+
+func newKafkaMessageAssembler(log logr.Logger,
+	fragmentInfoChan chan *kafkaMessageFragmentsInfo, msgChan chan *kafka.Message) *kafkaMessageAssembler {
+	return &kafkaMessageAssembler{
+		log:                   log,
+		fragmentCollectionMap: make(map[string]*kafkaMessageFragmentsCollection),
+		fragmentInfoChan:      fragmentInfoChan,
+		msgChan:               msgChan,
+		lock:                  sync.Mutex{},
+	}
+}
+
+type kafkaMessageAssembler struct {
+	log                   logr.Logger
+	fragmentCollectionMap map[string]*kafkaMessageFragmentsCollection
+	fragmentInfoChan      chan *kafkaMessageFragmentsInfo
+	msgChan               chan *kafka.Message
+	lock                  sync.Mutex
+}
+
+func (kma *kafkaMessageAssembler) Start(ctx context.Context) {
+	go kma.handleFragments(ctx)
+}
+
+func (kma *kafkaMessageAssembler) handleFragments(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			kma.log.Info("stopped kafka message assembler")
+			return
+
+		case fragInfo := <-kma.fragmentInfoChan:
+			fragCollection, found := kma.fragmentCollectionMap[fragInfo.key]
+			if !found || fragCollection.dismantlingTimestamp.Before(fragInfo.dismantlingTimestamp) {
+				// if collection is not mapped/if a new version is coming in, replace mapping with a fresh collection.
+				fragCollection = newKafkaMessageFragmentsCollection(fragInfo.totalSize, fragInfo.dismantlingTimestamp)
+				kma.fragmentCollectionMap[fragInfo.key] = fragCollection
+				fragCollection.AddFragment(fragInfo)
+
+				continue
+			} else if fragCollection.dismantlingTimestamp.After(fragInfo.dismantlingTimestamp) {
+				// got an outdated fragment
+				continue
+			}
+
+			// collection exists and the received fragment package should be added
+			fragCollection.AddFragment(fragInfo)
+
+			// check if got all and assemble
+			if fragCollection.totalMessageSize == fragCollection.accumulatedFragmentsSize {
+				// overtake the collection's latest kafka message, fill it with combined bundle and forward
+				fragmentsCount := len(fragCollection.messageFragments)
+
+				assembledBundle, _ := fragCollection.Assemble() // no error because checked assembling size requirement
+				fragCollection.latestKafkaMessage.Value = assembledBundle
+
+				// forward assembled bundle onwards (it has fragmented key identifier but complete content)
+				kma.msgChan <- fragCollection.latestKafkaMessage
+
+				kma.log.Info("assembled and forwarded fragments collection",
+					"collection key", fragInfo.key,
+					"collection size (bytes)", fragInfo.totalSize,
+					"fragments count", fragmentsCount)
+
+				// delete collection & info
+				delete(kma.fragmentCollectionMap, fragInfo.key)
+			}
+		}
+	}
+}

--- a/kafka-client/kafka-consumer/kafka_message_fragment_collection.go
+++ b/kafka-client/kafka-consumer/kafka_message_fragment_collection.go
@@ -1,0 +1,91 @@
+package kafkaconsumer
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+var errFragmentsAreIncomplete = fmt.Errorf("some fragments are missing")
+
+func newKafkaMessageFragmentsCollection(size uint32, timestamp time.Time) *kafkaMessageFragmentsCollection {
+	return &kafkaMessageFragmentsCollection{
+		totalMessageSize:         size,
+		accumulatedFragmentsSize: 0,
+		dismantlingTimestamp:     timestamp,
+		messageFragments:         make(map[uint32]*kafkaMessageFragment),
+		latestKafkaMessage:       nil,
+		lock:                     sync.Mutex{},
+	}
+}
+
+// kafkaMessageFragmentsCollection holds a collection of kafkaMessageFragment and maintains it until completion.
+type kafkaMessageFragmentsCollection struct {
+	totalMessageSize         uint32
+	accumulatedFragmentsSize uint32
+	dismantlingTimestamp     time.Time
+	messageFragments         map[uint32]*kafkaMessageFragment
+
+	latestKafkaMessage *kafka.Message
+	lock               sync.Mutex
+}
+
+// kafkaMessageFragment represents one fragment of a kafka message.
+type kafkaMessageFragment struct {
+	offset uint32
+	bytes  []byte
+}
+
+// kafkaMessageFragmentsInfo wraps a fragment with info to pass in channels.
+type kafkaMessageFragmentsInfo struct {
+	key                  string
+	totalSize            uint32
+	dismantlingTimestamp time.Time
+	fragment             *kafkaMessageFragment
+	kafkaMessage         *kafka.Message
+}
+
+func (fc *kafkaMessageFragmentsCollection) AddFragment(fragInfo *kafkaMessageFragmentsInfo) {
+	fc.lock.Lock()
+	defer fc.lock.Unlock()
+
+	if fragInfo.fragment.offset > fc.totalMessageSize {
+		return
+	}
+
+	// add fragment to collection, don't write if already exists.
+	if _, found := fc.messageFragments[fragInfo.fragment.offset]; !found {
+		fc.messageFragments[fragInfo.fragment.offset] = fragInfo.fragment
+	}
+
+	// update accumulated size.
+	fc.accumulatedFragmentsSize += uint32(len(fragInfo.fragment.bytes))
+
+	// update freshest kafka message if needed.
+	if fc.latestKafkaMessage == nil ||
+		fragInfo.kafkaMessage.TopicPartition.Offset >= fc.latestKafkaMessage.TopicPartition.Offset {
+		fc.latestKafkaMessage = fragInfo.kafkaMessage
+	}
+}
+
+// Assemble assembles the collection into one bundle.
+// This function only runs when totalMessageSize == accumulatedFragmentsSize.
+func (fc *kafkaMessageFragmentsCollection) Assemble() ([]byte, error) {
+	fc.lock.Lock()
+	defer fc.lock.Unlock()
+
+	if fc.totalMessageSize != fc.accumulatedFragmentsSize {
+		return nil, errFragmentsAreIncomplete
+	}
+
+	buf := make([]byte, fc.totalMessageSize)
+
+	for offset, frag := range fc.messageFragments {
+		copy(buf[offset:], frag.bytes)
+		frag.bytes = nil // faster GC
+	}
+
+	return buf, nil
+}

--- a/kafka-client/kafka-producer/kafka_message_dismantler.go
+++ b/kafka-client/kafka-producer/kafka_message_dismantler.go
@@ -1,0 +1,79 @@
+package kafkaproducer
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	types "github.com/open-cluster-management/hub-of-hubs-kafka-transport/types"
+)
+
+const intSize = 4
+
+var errFailedToDismantleMessage = fmt.Errorf("failed to dismantle message")
+
+func dismantleAndSendKafkaMessage(producer *KafkaProducer,
+	msgID []byte, msgType []byte, payload []byte) error {
+	dismantlingTime := time.Now().Format(types.TimeFormat)
+	dismantlingTimeBytes := []byte(dismantlingTime)
+
+	chunks := splitBufferByLimit(payload, producer.messageSizeLimit)
+
+	for idx, chunk := range chunks {
+		messageKey := fmt.Sprintf("%d_%s", idx, string(producer.key))
+		messageKeyBytes := []byte(messageKey)
+
+		messageBuilder := &KafkaMessageBuilder{}
+		kafkaMessage := messageBuilder.
+			Topic(&producer.topic, kafka.PartitionAny).
+			Key(messageKeyBytes).
+			Payload(chunk).
+			Header(kafka.Header{
+				Key: types.MsgTypeKey, Value: msgType,
+			}).
+			Header(kafka.Header{
+				Key: types.MsgIDKey, Value: msgID,
+			}).
+			Header(kafka.Header{
+				Key: types.HeaderSizeKey, Value: toByteArray(len(payload)),
+			}).
+			Header(kafka.Header{
+				Key: types.HeaderOffsetKey, Value: toByteArray(idx * producer.messageSizeLimit),
+			}).
+			Header(kafka.Header{
+				Key: types.HeaderDismantlingTimestamp, Value: dismantlingTimeBytes,
+			}).
+			Build()
+
+		if err := producer.kafkaProducer.Produce(kafkaMessage, producer.deliveryChan); err != nil {
+			return fmt.Errorf("%w: %v", errFailedToDismantleMessage, err)
+		}
+	}
+
+	return nil
+}
+
+func splitBufferByLimit(buf []byte, lim int) [][]byte {
+	var chunk []byte
+
+	chunks := make([][]byte, 0, len(buf)/lim+1)
+
+	for len(buf) >= lim {
+		chunk, buf = buf[:lim], buf[lim:]
+		chunks = append(chunks, chunk)
+	}
+
+	if len(buf) > 0 {
+		chunks = append(chunks, buf)
+	}
+
+	return chunks
+}
+
+func toByteArray(i int) []byte {
+	arr := make([]byte, intSize)
+	binary.BigEndian.PutUint32(arr[0:4], uint32(i))
+
+	return arr
+}


### PR DESCRIPTION
Added fragmentation logic to the internal logic of this component:
1. A dismantler (message -> fragments) on the producer side
2. An assembler (fragment -> message) on the consumer side

When a producer attempts to send a message with a payload size > configurable limit, the message is broken into fragments and its key is updated along with metadata headers. When a consumer detects these headers, it opens a fragments collection and builds it up as the fragments are consumed, then overtakes the most recent fragment's kafka message skeleton and uses it to pass along the assembled message.
