### PR TITLE
enabled compaction

### DIFF
--- a/deploy/kafka-cluster.yaml
+++ b/deploy/kafka-cluster.yaml
@@ -64,8 +64,7 @@ spec:
   partitions: 1
   replicas: 2
   config:
-    retention.ms: -1
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2
@@ -79,6 +78,5 @@ spec:
   partitions: 1
   replicas: 2
   config:
-    retention.ms: -1
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 


### PR DESCRIPTION
switched cleanup.policy to compact in spec+status topic deployments, which enables compaction:
- no retention, all messages remain forever but are compacted by key
- log segments are on default value (1gibibyte)
- compaction is triggered when on inactive segments when duplicates are no more than 50% of the log