### PR TITLE
update channel for amq-streams to 1.8.x

### DIFF
--- a/deploy/amq_streams_operator.yaml
+++ b/deploy/amq_streams_operator.yaml
@@ -17,7 +17,7 @@ metadata:
   name: amq-streams
   namespace: kafka
 spec:
-  channel: amq-streams-1.7.x
+  channel: amq-streams-1.8.x
   name: amq-streams 
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
the 1.7.x channel of amq-streams has been dropped, we need to upgrade the channel to `1.8.x`, otherwise the amq-streams will never be installed successfully.